### PR TITLE
Fixes #49 change qos 2 to 1, since bemfa not allow qos2

### DIFF
--- a/custom_components/bemfa/mqtt.py
+++ b/custom_components/bemfa/mqtt.py
@@ -54,7 +54,7 @@ class BemfaMqtt:
             TOPIC_PUBLISH.format(topic=sync.topic),
             sync.generate_msg(),
         )
-        self._mqttc.subscribe(sync.topic, 2)
+        self._mqttc.subscribe(sync.topic, 1)
 
     def modify_sync(self, sync: Sync):
         """Modify a sync."""
@@ -87,7 +87,7 @@ class BemfaMqtt:
         )
 
         # Listen for heartbeat packages
-        self._mqttc.subscribe(TOPIC_PING, 2)
+        self._mqttc.subscribe(TOPIC_PING, 1)
 
     def _ping(self):
         async def _receive_job():


### PR DESCRIPTION
https://cloud.bemfa.com/docs/src/mqtt.html

MQTT 支持Qos0 Qos1，支持retian保留消息，不支持qos2，使用qos2会被强制下线，次数过多可造成账号异常无法使用。