### PR TITLE
fix: Replace deprecated functions for Core 2025.12.1 compatibility

### DIFF
--- a/custom_components/bemfa/const.py
+++ b/custom_components/bemfa/const.py
@@ -2,7 +2,7 @@
 
 from typing import Final
 
-from homeassistant.backports.enum import StrEnum
+import enum
 
 DOMAIN: Final = "bemfa"
 
@@ -33,7 +33,7 @@ OPTIONS_SWING_VERTICAL_VALUE: Final = "swing_vertical_value"
 OPTIONS_SWING_BOTH_VALUE: Final = "swing_both_value"
 
 # #### MQTT ####
-class TopicSuffix(StrEnum):
+class TopicSuffix(enum.StrEnum):
     """Suffix for bemfa MQTT topic"""
 
     LIGHT = "002"

--- a/custom_components/bemfa/manifest.json
+++ b/custom_components/bemfa/manifest.json
@@ -10,7 +10,7 @@
   "homekit": {},
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/larry-wong/bemfa/issues",
-  "requirements": ["paho-mqtt==1.6.1"],
+  "requirements": ["paho-mqtt"],
   "ssdp": [],
   "version": "1.4.0",
   "zeroconf": []

--- a/custom_components/bemfa/mqtt.py
+++ b/custom_components/bemfa/mqtt.py
@@ -38,7 +38,7 @@ class BemfaMqtt:
         self._hass = hass
 
         # Init MQTT connection
-        self._mqttc = mqtt.Client(uid, mqtt.MQTTv311)
+        self._mqttc = mqtt.Client(client_id=uid, protocol=mqtt.MQTTv311, callback_api_version=mqtt.CallbackAPIVersion.VERSION1)
 
         self._topic_to_sync: dict[str, Sync] = {}
 

--- a/custom_components/bemfa/sync_light.py
+++ b/custom_components/bemfa/sync_light.py
@@ -6,9 +6,9 @@ from typing import Any
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT,
-    ATTR_COLOR_TEMP,
-    ATTR_MAX_MIREDS,
-    ATTR_MIN_MIREDS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_MIN_COLOR_TEMP_KELVIN,
+    ATTR_MAX_COLOR_TEMP_KELVIN,
     ATTR_RGB_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
     DOMAIN,
@@ -45,8 +45,8 @@ class Light(ControllableSync):
             lambda state, attributes: round(attributes[ATTR_BRIGHTNESS] / 2.55)
             if has_key(attributes, ATTR_BRIGHTNESS)
             else "",
-            lambda state, attributes: 1000000 // attributes[ATTR_COLOR_TEMP]
-            if has_key(attributes, ATTR_COLOR_TEMP)
+            lambda state, attributes: 1000000 // attributes[ATTR_COLOR_TEMP_KELVIN]
+            if has_key(attributes, ATTR_COLOR_TEMP_KELVIN)
             else attributes[ATTR_RGB_COLOR][0] * 256 * 256
             + attributes[ATTR_RGB_COLOR][1] * 256
             + attributes[ATTR_RGB_COLOR][2]
@@ -75,9 +75,9 @@ class Light(ControllableSync):
                     SERVICE_TURN_ON if msg[0] == MSG_ON else SERVICE_TURN_OFF,
                     {
                         ATTR_BRIGHTNESS_PCT: msg[1],
-                        ATTR_COLOR_TEMP: min(
-                            max(1000000 // msg[2], attributes[ATTR_MIN_MIREDS]),
-                            attributes[ATTR_MAX_MIREDS],
+                        ATTR_COLOR_TEMP_KELVIN: min(
+                            max(1000000 // msg[2], attributes[ATTR_MAX_COLOR_TEMP_KELVIN]),
+                            attributes[ATTR_MIN_COLOR_TEMP_KELVIN],
                         ),
                     }
                     if len(msg) > 2

--- a/custom_components/bemfa/sync_sensor.py
+++ b/custom_components/bemfa/sync_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
     SelectSelectorMode,
 )
-from homeassistant.helpers.template import area_entities
+from homeassistant.helpers import entity_registry as er
 from .utils import has_key
 from .const import (
     OPTIONS_CO2,
@@ -57,7 +57,11 @@ class Sensor(Sync):
         co2_sensors: dict[str, str] = {}
 
         # filter entities in our area
-        a_entities = area_entities(self._hass, self._entity_id.split(".")[1])
+        area_id = self._entity_id.split(".")[1]
+        entity_reg = er.async_get(self._hass)
+        a_entities = {
+            entry.entity_id for entry in entity_reg.async_entries_for_area(area_id)
+        }
 
         for state in self._hass.states.async_all(SENSOR_DOMAIN):
             if state.entity_id not in a_entities:

--- a/custom_components/bemfa/sync_switch.py
+++ b/custom_components/bemfa/sync_switch.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 from collections.abc import Mapping, Callable
 from typing import Any
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
-from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN, STATE_IDLE
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN, CameraState
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
 from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
 from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
-from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
@@ -20,7 +20,7 @@ from homeassistant.components.vacuum import (
     SERVICE_RETURN_TO_BASE,
     SERVICE_START,
     SERVICE_STOP,
-    STATE_CLEANING,
+    VacuumActivity,
     VacuumEntityFeature,
 )
 from homeassistant.const import (
@@ -29,7 +29,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     SERVICE_UNLOCK,
     SERVICE_LOCK,
-    STATE_LOCKED,
     STATE_ON,
     STATE_PLAYING,
 )
@@ -120,7 +119,7 @@ class Camera(Switch):
     def _msg_generator(
         self,
     ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_OFF if state == STATE_IDLE else MSG_ON
+        return lambda state, attributes: MSG_OFF if state == CameraState.IDLE else MSG_ON
 
 
 @SYNC_TYPES.register("media_player")
@@ -148,7 +147,7 @@ class Lock(Switch):
     def _msg_generator(
         self,
     ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_OFF if state == STATE_LOCKED else MSG_ON
+        return lambda state, attributes: MSG_OFF if state == LockState.LOCKED else MSG_ON
 
     def _service_names(self) -> tuple[str, str]:
         return (SERVICE_UNLOCK, SERVICE_LOCK)
@@ -193,7 +192,7 @@ class Vacuum(Switch):
     ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
         return (
             lambda state, attributes: MSG_ON
-            if state in [STATE_ON, STATE_CLEANING]
+            if state in [STATE_ON, VacuumActivity.CLEANING]
             else MSG_OFF
         )
 


### PR DESCRIPTION
### 适配 Core 2025.12.1
- 替换已移除的 area_entities 函数，通过实体注册表按区域过滤传感器

### 替换已弃用的函数
 
| **已弃用函数**         | **新函数**                   |
|-------------------|---------------------------|
| `ATTR_MAX_MIREDS` | `ATTR_MIN_COLOR_TEMP_KELVIN` |
| `ATTR_MIN_MIREDS` | `ATTR_MAX_COLOR_TEMP_KELVIN` |
| `ATTR_COLOR_TEMP` | `ATTR_COLOR_TEMP_KELVIN`     |
| `STATE_CLEANING`  | `VacuumActivity.CLEANING`   |
| `STATE_LOCKED`    | `LockState.LOCKED`          |
| `STATE_IDLE`      | `CameraState.IDLE`          |
| `StrEnum`         | `enum.StrEnum`              |
