### PR TITLE
Fix deprecated constants

### DIFF
--- a/custom_components/bemfa/sync_switch.py
+++ b/custom_components/bemfa/sync_switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Callable
 from typing import Any
 from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
-from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN, STATE_IDLE
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
 from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
 from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
@@ -29,7 +29,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     SERVICE_UNLOCK,
     SERVICE_LOCK,
-    STATE_LOCKED,
     STATE_ON,
     STATE_PLAYING,
 )
@@ -120,7 +119,7 @@ class Camera(Switch):
     def _msg_generator(
         self,
     ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_OFF if state == STATE_IDLE else MSG_ON
+        return lambda state, attributes: MSG_OFF if state == "idle" else MSG_ON
 
 
 @SYNC_TYPES.register("media_player")
@@ -148,7 +147,7 @@ class Lock(Switch):
     def _msg_generator(
         self,
     ) -> Callable[[str, ReadOnlyDict[Mapping[str, Any]]], str | int]:
-        return lambda state, attributes: MSG_OFF if state == STATE_LOCKED else MSG_ON
+        return lambda state, attributes: MSG_OFF if state == "locked" else MSG_ON
 
     def _service_names(self) -> tuple[str, str]:
         return (SERVICE_UNLOCK, SERVICE_LOCK)


### PR DESCRIPTION
现在homeassistant实体的外部表示已经改成字符串形式了

https://github.com/home-assistant/core/pull/153363

```STATE_LOCKED``` 和 ```STATE_IDLE``` 被移除，这里使用字符串代替判断